### PR TITLE
fix: mobile nav menu "Home" link overlapping header

### DIFF
--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -214,7 +214,7 @@ export default function SiteHeader({ onOpenCommandPalette }: SiteHeaderProps) {
             animate={{ opacity: 1 }}
             exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0 }}
             transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.3, ease: "easeOut" }}
-            className="fixed inset-0 z-40 flex flex-col bg-slate-950/98 backdrop-blur-lg md:hidden overflow-y-auto will-change-[opacity]"
+            className="fixed inset-0 z-40 flex flex-col bg-slate-950/98 backdrop-blur-lg md:hidden overflow-y-auto will-change-[opacity] pt-24"
             style={{ transform: "translateZ(0)" }}
             role="dialog"
             aria-modal="true"
@@ -227,7 +227,7 @@ export default function SiteHeader({ onOpenCommandPalette }: SiteHeaderProps) {
             
             <nav className="relative flex flex-1 flex-col justify-center px-8">
               <motion.div
-                className="flex flex-col gap-8"
+                className="flex flex-col gap-6"
                 initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.3, ease: "easeOut" }}
@@ -251,7 +251,7 @@ export default function SiteHeader({ onOpenCommandPalette }: SiteHeaderProps) {
                 })}
               </motion.div>
 
-              <div className="mt-16">
+              <div className="mt-10">
                 <Link
                   href="/contact"
                   className="flex w-full items-center justify-center rounded-full bg-white py-4 text-lg font-bold text-slate-950 shadow-lg shadow-white/10 transition-transform active:scale-95"


### PR DESCRIPTION
## Summary
- Fixes mobile navigation menu where the "Home" link was rendering behind/overlapping the fixed header

## Problem
On mobile devices, when opening the hamburger menu, the first nav item ("Home") appeared in the same position as the site logo and name in the header, creating a visual overlap.

## Solution
Three Tailwind CSS adjustments to the mobile menu overlay in `components/site-header.tsx`:

| Change | Before | After | Purpose |
|--------|--------|-------|---------|
| Top padding | (none) | `pt-24` | Push nav content below the fixed header |
| Nav item gap | `gap-8` | `gap-6` | Fit all items on screen |
| CTA button margin | `mt-16` | `mt-10` | Ensure "Get in touch" button is visible |

## Test plan
- [x] Open site on mobile viewport (390×844)
- [x] Tap hamburger menu
- [x] Verify "Home" has proper spacing from header
- [x] Verify all nav items visible
- [x] Verify "Get in touch" button visible without scrolling